### PR TITLE
update-flake-15672056644

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -424,11 +424,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1749754824,
-        "narHash": "sha256-4np99yTzIyosbx8hUvkOaaMoLuQpWIwNmkcYR2F8uXM=",
+        "lastModified": 1750035215,
+        "narHash": "sha256-xGPyPewHUX1Rj0KtwkY6GlpUJim5rJrJ11PP0ZtZq3I=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "3308d82c470d2614530536b8a69169ebc61eb1b5",
+        "rev": "682e202b5eedcf2b2c6e916c08bc93c683af922d",
         "type": "github"
       },
       "original": {
@@ -457,11 +457,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1749752245,
-        "narHash": "sha256-AOiLFwSsLC86GFPUZQJwW1ZsWKKtbR/G85SbmtkEuuk=",
+        "lastModified": 1749797708,
+        "narHash": "sha256-P5x0U6AW5Zn20bARv4D83d8XlNaWK1st9QwBfSe+Vfg=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "97dfd2b1a00bcb9b765a8fa92ce39d2e0c79abc2",
+        "rev": "f3f6e79eeca8924ff9cfea4b30006e5b782bc93e",
         "type": "github"
       },
       "original": {
@@ -495,11 +495,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1749195551,
-        "narHash": "sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM=",
+        "lastModified": 1749832440,
+        "narHash": "sha256-lfxhuxAaHlYFGr8yOrAXZqdMt8PrFLzjVqH9v3lQaoY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4602f7e1d3f197b3cb540d5accf5669121629628",
+        "rev": "db030f62a449568345372bd62ed8c5be4824fa49",
         "type": "github"
       },
       "original": {
@@ -511,11 +511,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749727998,
-        "narHash": "sha256-mHv/yeUbmL91/TvV95p+mBVahm9mdQMJoqaTVTALaFw=",
+        "lastModified": 1749857119,
+        "narHash": "sha256-tG5xUn3hFaPpAHYIvr2F88b+ovcIO5k1HqajFy7ZFPM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd487183437963a59ba763c0cc4f27e3447dd6dd",
+        "rev": "5f4f306bea96741f1588ea4f450b2a2e29f42b98",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749695868,
-        "narHash": "sha256-debjTLOyqqsYOUuUGQsAHskFXH5+Kx2t3dOo/FCoNRA=",
+        "lastModified": 1750041667,
+        "narHash": "sha256-/8F9L6T9w/Fx1D6L+BtWIXg5m9F6jwOFg6uhZpKnM/0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "55f914d5228b5c8120e9e0f9698ed5b7214d09cd",
+        "rev": "d72bd8c9fda03c9834ea89d7a5a21c7880b79277",
         "type": "github"
       },
       "original": {
@@ -611,11 +611,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749768934,
-        "narHash": "sha256-xtWRTlYBs+wYE8NaV+mwdlVYWX0k2BkCuFdjexjEebY=",
+        "lastModified": 1750025377,
+        "narHash": "sha256-7gCZ+W0lMLIOvGjgLqej9pwS4cNd8ohnFxpm/JZxeTY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e1cfc2b69432ac2abe95db133dcbdfc96cd3bedb",
+        "rev": "2945d80172e0a82bbdbfe44c205d28ee5d097a5a",
         "type": "github"
       },
       "original": {
@@ -790,11 +790,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "type": "github"
       },
       "original": {
@@ -845,11 +845,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749745531,
-        "narHash": "sha256-+nnmuYVhQPbELuW2lZCWpTAJo955Qng/SCcLVO/RP6c=",
+        "lastModified": 1749991041,
+        "narHash": "sha256-+jss4bkSbzURttaspRke/LVtrthBRDoafJmn/xem5f0=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "50ec60bcf3528db062700673f61f86d82ca6cda0",
+        "rev": "ff841ca63c73796117f298c730d9f1dc2b18e7e7",
         "type": "github"
       },
       "original": {
@@ -867,11 +867,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749774922,
-        "narHash": "sha256-PfTJwBHpKy1wZRKwiMKyODazbPHUdMoAdnCHlhymos4=",
+        "lastModified": 1749989539,
+        "narHash": "sha256-ooEz7NPaAarC5lfODLufxQL0YKc10RBdgnmUvPlAGZQ=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "8966db663eb7c26aae37723dadce5a6b0fd809b8",
+        "rev": "ce80e663e44b435adb5e5420d6b4d285c3cce4e9",
         "type": "github"
       },
       "original": {
@@ -891,11 +891,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749606427,
-        "narHash": "sha256-kLiowPmyi7kiyExYAdLrlYHPMkLG3d1K+1SoMqvU7WI=",
+        "lastModified": 1750001019,
+        "narHash": "sha256-6FZqtpwBDjF3TCRIhfHPOofc4/uWwF2rYwvOOR1Ve+A=",
         "owner": "zigtools",
         "repo": "zls",
-        "rev": "4acbe890df5ab064c097ad88f065f86741ae3712",
+        "rev": "56e25ab5237676bb6e59eb8fbcabb1a842736119",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# nix-update-report for fd487183437963a59ba763c0cc4f27e3447dd6dd -> 5f4f306bea96741f1588ea4f450b2a2e29f42b98
Report generated using [`nix-update-reporter`](https://github.com/aldenparker/nix-update-report.git).

## Stats
Total Added: 1
Total Updated: 55
Total Removed: 0
Total Same: 24684
Total Pkgs: 24740

## Pkg Changes
### Added
 - xnconvert: 1.105.0

### Updated
 - firebird: 2.5.9 -> unknown
 - nextcloud: 30.0.11 -> 30.0.12
 - pyfa: 2.62.3 -> 2.63.1
 - amiri: 1.002 -> 1.003
 - cloudflare-dyndns: 5.3 -> 5.4
 - librewolf: 139.0.1-1 -> 139.0.4-1
 - grafana: 12.0.0 -> 12.0.1
 - wireshark-cli: 4.4.6 -> 4.4.7
 - heroic-unwrapped: 2.17.1 -> 2.17.2
 - signal-desktop: 7.56.0 -> 7.56.1
 - geteduroam-cli: 0.10 -> 0.12
 - gitaly: 18.0.1 -> 18.0.2
 - nexusmods-app: 0.11.3 -> 0.12.3
 - heroic: 2.17.1 -> 2.17.2
 - fractal: 11.1 -> 11.2
 - element-web: 1.11.102 -> 1.11.103
 - t1lib: 5.1.2 -> unknown
 - linux-firmware: 20250509 -> 20250613
 - slrn: 1.0.3a -> unknown
 - shader-slang: 2025.6.1 -> 2025.8.1
 - vivaldi: 7.4.3684.46 -> 7.4.3684.50
 - yabar: unstable-2018-01-18 -> unknown
 - linux-firmware: 20250509 -> 20250613
 - wlvncc: unstable-2024-11-23 -> 0-unstable-2025-04-21
 - ocsp-server: 0.4.1 -> 0.6.0
 - wireshark-qt: 4.4.6 -> 4.4.7
 - amd-ucode: 20250509 -> 20250613
 - xburst-tools: 2011-12-26 -> unknown
 - searxng: 0-unstable-2025-04-09 -> 0-unstable-2025-06-10
 - signal-desktop: 7.56.0 -> 7.56.1
 - gitlab-ee: 18.0.1 -> 18.0.2
 - raycast: 1.99.2 -> 1.100.0
 - gitlab-workhorse: 18.0.1 -> 18.0.2
 - gitlab-container-registry: 4.22.0 -> 4.23.1
 - memos: 0.24.3 -> 0.24.4
 - firefly-iii-data-importer: 1.6.1 -> 1.6.3
 - element-desktop: 1.11.102 -> 1.11.103
 - scrcpy: 3.2 -> 3.3
 - librewolf-unwrapped: 139.0.1-1 -> 139.0.4-1
 - VictoriaMetrics: 1.118.0 -> 1.119.0
 - yabar: 0.4.0 -> unknown
 - librewolf: 139.0.1-1 -> 139.0.4-1
 - wireshark-qt: 4.4.6 -> 4.4.7
 - fractal: 11.1 -> 11.2
 - nextcloud: 31.0.5 -> 31.0.6
 - nexusmods-app-unfree: 0.11.3 -> 0.12.3
 - gitlab: 18.0.1 -> 18.0.2
 - amd-ucode: 20250509 -> 20250613
 - gitlab-pages: 18.0.1 -> 18.0.2
 - wireshark-cli: 4.4.6 -> 4.4.7
 - element-web: 1.11.102 -> 1.11.103
 - VictoriaMetrics: 1.118.0 -> 1.119.0
 - nixpkgs-review: 3.2.0 -> 3.4.0
 - snac2: 2.77 -> 2.78
 - vbetool: 1.1 -> unknown

### Removed
None
